### PR TITLE
 astropysics.coords.AngularCoordinate.getDmsStr  broken for -1deg<angles<0deg

### DIFF
--- a/astropysics/coords/coordsys.py
+++ b/astropysics/coords/coordsys.py
@@ -478,7 +478,7 @@ class AngularCoordinate(object):
             sgn = '-' if self._decval < 0 else '+'
             return '%s%02.i:%02.i:%05.2f'%(sgn,abs(d),m,s)
         
-        d,m=str(d),str(m)
+        d,m=str(abs(d)),str(m)
         
         s = secform%s
         
@@ -491,6 +491,8 @@ class AngularCoordinate(object):
         
         if sign and self._decval  >= 0:
             tojoin.append('+')
+        if self._decval<0:
+            tojoin.append('-')
         
         if d is not '0':
             tojoin.append(d)


### PR DESCRIPTION
Hi, 

The current behaviour of astropysics.coords.AngularCoordinate.getDmsStr  was horribly broken for negative angles between -1 and 0 degrees

print astropysics.coords.AngularCoordinate(-.7).getDmsStr(sep=':',canonical=True)
00:42:00.00

I fixed the canonical case. For the noncanonical, I don't really understand its behaviour even for positive values

print astropysics.coords.AngularCoordinate(.7).getDmsStr(sep=':')
+42:00.00

Cheers,
    Sergey
