### PR TITLE
Fix indentation error in ipy_profile_astpys.py

### DIFF
--- a/astropysics/data/ipy_profile_astpys.py
+++ b/astropysics/data/ipy_profile_astpys.py
@@ -21,7 +21,7 @@ ip.ex("from scipy import stats,optimize,ndimage,integrate,interpolate,special")
 try:
     ip.ex("import pyfits")
 except ImportError:
-        pass
+    pass
     try:
         ip.ex("import asciitable")
     except ImportError:


### PR DESCRIPTION
The proposed fix might still not get the indentation right, depending on whether the intent is to try to install ``asciitable`` only if ``pyfits`` fails or the intent is to always try to install ``asciitable``